### PR TITLE
Docs/fix planner vlm readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ download urls:
 
 ```bash
 vllm serve MobiMind-Reasoning-4B --port <decider/grounder port>
-vllm serve Qwen/Qwen3-4B-Instruct --port <planner port>
+vllm serve Qwen/Qwen3-VL-4B-Instruct --port <planner port>
 ```
 
 #### 4. Agent Memory Setup (Optional)


### PR DESCRIPTION
[docs] Fix planner deployment model name in README

The README currently shows the planner deployment command as:

`vllm serve Qwen/Qwen3-4B-Instruct --port <planner port>`

However, there does not appear to be a current model published under the exact name `Qwen/Qwen3-4B-Instruct`.

From my investigation, the two closest plausible candidates are:
- `Qwen/Qwen3-VL-4B-Instruct`
- `Qwen/Qwen3-4B-Instruct-2507`

Why this should be changed

The issue is not only that the current README example points to a model name that likely does not exist as written, but also that the replacement should match the documented capability requirements of the planner side.

While the MobiAgent core paper does not explicitly state that the planner must be multimodal, the repository documentation suggests that the planner client is expected to support image understanding flows.

In particular, `runner/mobiagent/workflow/README_zh.md` documents the built-in `vlm_qa` tool and states that it “reuses the planner client to perform image question answering or image summarization”. This implies that, in at least one documented workflow path, the planner client is used for image-based reasoning rather than text-only reasoning.

That point matters for choosing between the two plausible candidate model names above:

- `Qwen/Qwen3-4B-Instruct-2507` is a text-only model, so it would not be consistent with a workflow that reuses the planner client for image question answering or image summarization.
- `Qwen/Qwen3-VL-4B-Instruct` is multimodal, so it is the more consistent replacement for the planner deployment example.

For that reason, this patch updates the README to use `Qwen/Qwen3-VL-4B-Instruct`.

This patch intentionally keeps the change minimal:
- it only corrects the README deployment example
- it does not change runtime code
- it does not broaden the scope into a larger model-selection policy discussion

Impact

- Avoids directing users to a model name that likely does not exist as written.
- Clarifies why the more plausible replacement is the multimodal `Qwen/Qwen3-VL-4B-Instruct` rather than the text-only `Qwen/Qwen3-4B-Instruct-2507`.
- Aligns the top-level deployment example with the repository's documented workflow behavior.

Signed-off-by: 23301078 <23301078@bjtu.edu.cn>