### PR TITLE
fix(workflow): allow disabling e2e mode

### DIFF
--- a/runner/mobiagent/mobiagent.py
+++ b/runner/mobiagent/mobiagent.py
@@ -1663,7 +1663,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--data_dir", type=str, default=None, help="Directory to save data (default: ./data relative to script location)")
     parser.add_argument("--task_file", type=str, default=None, help="Path to task.json file (default: ./task.json relative to script location)")
-    parser.add_argument("--e2e", action="store_true", default=True, help="Enable e2e mode: use e2e_qwen3.md as decider prompt and return coordinates directly from decider (default: True)")
+    parser.add_argument("--e2e", action=argparse.BooleanOptionalAction, default=False, help="Enable or disable e2e mode: use e2e_qwen3.md as decider prompt and return coordinates directly from decider (default: False)")
     parser.add_argument(
         "--decider_protocol",
         choices=SUPPORTED_DECIDER_PROTOCOLS,

--- a/runner/mobiagent/workflow/engine.py
+++ b/runner/mobiagent/workflow/engine.py
@@ -192,7 +192,7 @@ class WorkflowRunner:
         device_type: str = "Android",
         output_dir: str | None = None,
         use_qwen3: bool = True,
-        use_e2e: bool = True,
+        use_e2e: bool | None = None,
         enable_user_profile: bool = False,
         use_graphrag: bool = False,
         auto_accept_planner_changes: bool = False,
@@ -426,7 +426,12 @@ class WorkflowRunner:
         current_device_type = step.get("device", self.device_type)
         device = self._get_device(current_device_type)
         use_experience = bool(step.get("use_experience", self.defaults.get("use_experience", False)))
-        use_e2e = bool(step.get("use_e2e", self.defaults.get("use_e2e", self.use_e2e)))
+        if "use_e2e" in step:
+            use_e2e = bool(step["use_e2e"])
+        elif self.use_e2e is not None:
+            use_e2e = bool(self.use_e2e)
+        else:
+            use_e2e = bool(self.defaults.get("use_e2e", False))
         use_qwen3 = bool(step.get("use_qwen3", self.defaults.get("use_qwen3", self.use_qwen3)))
         use_graphrag = bool(step.get("use_graphrag", self.defaults.get("use_graphrag", self.use_graphrag)))
         decider_protocol = str(

--- a/runner/mobiagent/workflow/examples/01_basic_gui_task_weixin_v2.json
+++ b/runner/mobiagent/workflow/examples/01_basic_gui_task_weixin_v2.json
@@ -6,7 +6,7 @@
   "defaults": {
     "device": "Harmony",
     "use_qwen3": true,
-    "use_e2e": true,
+    "use_e2e": false,
     "use_experience": false,
     "accept_planner_changes": false
   },

--- a/runner/mobiagent/workflow/test_workflow_e2e_flags.py
+++ b/runner/mobiagent/workflow/test_workflow_e2e_flags.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from runner.mobiagent.workflow.engine import WorkflowContext, WorkflowRunner
+from runner.mobiagent.workflow_runner import build_parser
+
+
+class WorkflowE2EFlagTests(unittest.TestCase):
+    def test_workflow_cli_can_disable_e2e(self) -> None:
+        parser = build_parser()
+
+        args = parser.parse_args(["--workflow_file", "workflow.json", "--no-e2e"])
+
+        self.assertFalse(args.e2e)
+
+    def test_explicit_cli_e2e_value_overrides_workflow_default(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = WorkflowRunner.__new__(WorkflowRunner)
+            runner.defaults = {"use_e2e": True}
+            runner.use_e2e = False
+            runner.use_qwen3 = True
+            runner.use_graphrag = False
+            runner.auto_accept_planner_changes = False
+            runner.decider_protocol = "qwen_json"
+            runner.device_type = "Harmony"
+            runner.current_app_name = "微信"
+            runner.current_package_name = "com.tencent.mm"
+            runner.context = WorkflowContext(Path("workflow.json"), Path(temp_dir), {})
+
+            with (
+                patch.object(runner, "_prepare_step_dir", return_value=Path(temp_dir)),
+                patch.object(runner, "_get_device", return_value=object()),
+                patch("runner.mobiagent.workflow.engine.mobiagent.task_in_app") as task_in_app,
+            ):
+                runner._run_gui_task(
+                    {
+                        "id": "2",
+                        "type": "gui_task",
+                        "task_description": "搜索小赵",
+                    },
+                    "2",
+                )
+
+        self.assertFalse(task_in_app.call_args.args[8])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runner/mobiagent/workflow_runner.py
+++ b/runner/mobiagent/workflow_runner.py
@@ -32,7 +32,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--user_profile", choices=["on", "off"], default="off", help="Enable user profile memory")
     parser.add_argument("--use_graphrag", choices=["on", "off"], default="off", help="Enable GraphRAG for user profile memory")
     parser.add_argument("--use_qwen3", choices=["on", "off"], default="on", help="Use Qwen3 for GUI execution steps")
-    parser.add_argument("--e2e", action="store_true", default=True, help="Enable e2e mode for GUI task steps")
+    parser.add_argument(
+        "--e2e",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable e2e mode for GUI task steps",
+    )
     parser.add_argument("--output_dir", type=str, default=None, help="Directory for workflow run outputs")
     parser.add_argument(
         "--decider_protocol",


### PR DESCRIPTION
The workflow CLI currently defines --e2e as store_true with default=True, so e2e mode is enabled whether the user passes the flag or not.

This is especially problematic for runner/mobiagent/workflow/examples/01_basic_gui_task_weixin_v2.json because the workflow default is also use_e2e=true. In that configuration GUI task steps skip Grounder and require the Decider to return executable bbox values directly.

Why this should be changed

Users need a CLI-level way to force the documented Decider + Grounder path when a workflow file defaults to e2e mode.

A store_true flag with default=True cannot express that choice: not passing --e2e and passing --e2e both produce True.

This patch changes the workflow CLI to use argparse.BooleanOptionalAction so --e2e enables e2e mode and --no-e2e disables it. The workflow runner now treats the CLI value as tri-state: per-step use_e2e still has highest priority, an explicitly supplied CLI value overrides workflow defaults, and workflow defaults apply when the CLI does not specify either form.

The direct mobiagent CLI is also aligned with the documented non-e2e default by using the same boolean optional flag shape with default False.

This patch intentionally keeps the change minimal:

it only changes e2e flag parsing and resolution
it changes the Weixin v2 example default to use Grounder by default it adds focused regression coverage for disabling e2e and overriding workflow defaults

Impact

Allows users to run workflows through the Decider + Grounder path with --no-e2e. Avoids forcing the Weixin v2 workflow into e2e mode by default. Preserves per-step use_e2e overrides for workflows that intentionally mix modes.