### PR TITLE
fix(workflow): preserve loop body failures

### DIFF
--- a/runner/mobiagent/workflow/engine.py
+++ b/runner/mobiagent/workflow/engine.py
@@ -663,7 +663,10 @@ class WorkflowRunner:
             local_aliases: dict[str, str] = {}
             with self.context.push_scope(local_aliases, loop_runtime):
                 stopped = self._execute_steps_in_scope(body_steps, iteration_prefix, local_aliases)
-                should_break = self._evaluate_condition(break_if_condition) if break_if_condition is not None else False
+                if stopped:
+                    should_break = False
+                else:
+                    should_break = self._evaluate_condition(break_if_condition) if break_if_condition is not None else False
             executed_iterations.append(
                 {
                     "iteration": iteration_index + 1,

--- a/runner/mobiagent/workflow/test_workflow_loop_failures.py
+++ b/runner/mobiagent/workflow/test_workflow_loop_failures.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from runner.mobiagent.workflow.engine import WorkflowContext, WorkflowRunner
+
+
+class WorkflowLoopFailureTests(unittest.TestCase):
+    def test_loop_body_failure_is_not_masked_by_break_condition(self) -> None:
+        runner = WorkflowRunner.__new__(WorkflowRunner)
+        runner.context = WorkflowContext(Path("workflow.json"), Path("."), {})
+
+        step = {
+            "id": "3",
+            "type": "loop",
+            "max_times": 1,
+            "break_if": {
+                "left": "${steps.2.output.structured_output.contains_today_chat}",
+                "operator": "==",
+                "right": False,
+            },
+            "steps": [],
+        }
+
+        with patch.object(runner, "_execute_steps_in_scope", return_value=True):
+            with self.assertRaisesRegex(RuntimeError, "Loop body stopped at iteration 1"):
+                runner._run_loop(step, "3")
+
+    def test_loop_break_condition_can_read_current_iteration_tool_output(self) -> None:
+        runner = WorkflowRunner.__new__(WorkflowRunner)
+        runner.context = WorkflowContext(Path("workflow.json"), Path("."), {})
+
+        step = {
+            "id": "3",
+            "type": "loop",
+            "max_times": 1,
+            "break_if": {
+                "left": "${steps.2.output.structured_output.contains_today_chat}",
+                "operator": "==",
+                "right": False,
+            },
+            "steps": [],
+        }
+
+        def execute_body(_body_steps, actual_prefix, local_aliases):
+            result = type(
+                "Result",
+                (),
+                {
+                    "to_dict": lambda self: {
+                        "output": {
+                            "structured_output": {
+                                "contains_today_chat": False,
+                            }
+                        }
+                    }
+                },
+            )()
+            local_aliases["2"] = f"{actual_prefix}.2"
+            runner.context.step_results[f"{actual_prefix}.2"] = result
+            return False
+
+        with patch.object(runner, "_execute_steps_in_scope", side_effect=execute_body):
+            output = runner._run_loop(step, "3")
+
+        self.assertTrue(output["broke_early"])
+        self.assertEqual(output["break_iteration"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Workflow loops currently evaluate break_if after executing the loop body even when the body has already reported a stopping failure.

That behavior can mask the original failure. For example, runner/mobiagent/workflow/examples/01_basic_gui_task_weixin_v2.json checks:

${steps.2.output.structured_output.contains_today_chat}

When the vlm_qa tool step fails, its output is empty. The loop then tries to evaluate break_if anyway and raises a secondary 'structured_output' KeyError instead of preserving the original tool failure.

Why this should be changed

The loop body failure is the actionable error. Evaluating break_if after a failed body depends on outputs that may not exist, and it can replace the real failure with a misleading variable-resolution error.

The condition is still evaluated after successful loop body iterations, so workflows such as the Weixin v2 chat collection flow can continue to use local loop aliases like steps.2 to read the current iteration's vlm_qa structured output.

This patch intentionally keeps the change minimal:

it only skips break_if evaluation when the loop body has already stopped it does not change loop alias resolution
it adds regression coverage for both the failure path and the successful current-iteration break_if path

Impact

Preserves the original loop body failure in workflow summaries and logs. Avoids misleading 'structured_output' KeyError failures after a tool step has already failed. Keeps successful loop break_if behavior unchanged for current-iteration tool outputs.