### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,4 +338,4 @@ We gratefully acknowledge the open-source projects like MobileAgent, UI-TARS, an
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=IPADS-SAI/MobiAgent&type=Date)](https://www.star-history.com/#IPADS-SAI/MobiAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=IPADS-SAI/MobiAgent&type=Date)](https://star-history.dera.page/#IPADS-SAI/MobiAgent&type=Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -339,4 +339,4 @@ python -m runner.mobiagent.multi_task.mobiagent_refactored \
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=IPADS-SAI/MobiAgent&type=Date)](https://www.star-history.com/#IPADS-SAI/MobiAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=IPADS-SAI/MobiAgent&type=Date)](https://star-history.dera.page/#IPADS-SAI/MobiAgent&type=Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working provider so it renders correctly again.